### PR TITLE
remove state change handler on map unload

### DIFF
--- a/core/scripts_modactive/tachy-guns.lua
+++ b/core/scripts_modactive/tachy-guns.lua
@@ -40,6 +40,7 @@ end
 dfhack.onStateChange[GLOBAL_KEY] = function(stateChange)
 	if stateChange == SC_MAP_UNLOADED then
 		dfhack.run_command("disable", "tachy-guns")
+		dfhack.onStateChange[GLOBAL_KEY] = nil
 		return
 	end
 	if stateChange ~= SC_MAP_LOADED or df.global.gamemode ~= df.game_mode.DWARF then


### PR DESCRIPTION
so the mod doesn't enable itself on worlds loaded later in the same play session that do *not* have the mod active